### PR TITLE
Update CodeInspectionType in empty block inspections

### DIFF
--- a/Rubberduck.Inspections/Concrete/EmptyCaseBlockInspection.cs
+++ b/Rubberduck.Inspections/Concrete/EmptyCaseBlockInspection.cs
@@ -19,7 +19,7 @@ namespace Rubberduck.Inspections.Concrete
         public override IInspectionListener Listener { get; } =
             new EmptyCaseBlockListener();
 
-        public override CodeInspectionType InspectionType => CodeInspectionType.CodeQualityIssues;
+        public override CodeInspectionType InspectionType => CodeInspectionType.MaintainabilityAndReadabilityIssues;
 
         protected override IEnumerable<IInspectionResult> DoGetInspectionResults()
         {

--- a/Rubberduck.Inspections/Concrete/EmptyDoWhileBlockInspection.cs
+++ b/Rubberduck.Inspections/Concrete/EmptyDoWhileBlockInspection.cs
@@ -16,7 +16,7 @@ namespace Rubberduck.Inspections.Concrete
         public EmptyDoWhileBlockInspection(RubberduckParserState state)
             : base(state, CodeInspectionSeverity.Suggestion) { }
 
-        public override CodeInspectionType InspectionType => CodeInspectionType.CodeQualityIssues;
+        public override CodeInspectionType InspectionType => CodeInspectionType.MaintainabilityAndReadabilityIssues;
 
         protected override IEnumerable<IInspectionResult> DoGetInspectionResults()
         {

--- a/Rubberduck.Inspections/Concrete/EmptyElseBlockInspection.cs
+++ b/Rubberduck.Inspections/Concrete/EmptyElseBlockInspection.cs
@@ -16,7 +16,7 @@ namespace Rubberduck.Inspections.Concrete
         public EmptyElseBlockInspection(RubberduckParserState state)
             : base(state, CodeInspectionSeverity.DoNotShow) { }
 
-        public override CodeInspectionType InspectionType => CodeInspectionType.CodeQualityIssues;
+        public override CodeInspectionType InspectionType => CodeInspectionType.MaintainabilityAndReadabilityIssues;
 
         protected override IEnumerable<IInspectionResult> DoGetInspectionResults()
         {

--- a/Rubberduck.Inspections/Concrete/EmptyForEachBlockInspection.cs
+++ b/Rubberduck.Inspections/Concrete/EmptyForEachBlockInspection.cs
@@ -16,7 +16,7 @@ namespace Rubberduck.Inspections.Concrete
         public EmptyForEachBlockInspection(RubberduckParserState state)
             : base(state, CodeInspectionSeverity.DoNotShow) { }
 
-        public override CodeInspectionType InspectionType => CodeInspectionType.CodeQualityIssues;
+        public override CodeInspectionType InspectionType => CodeInspectionType.MaintainabilityAndReadabilityIssues;
 
         protected override IEnumerable<IInspectionResult> DoGetInspectionResults()
         {

--- a/Rubberduck.Inspections/Concrete/EmptyForLoopBlockInspection.cs
+++ b/Rubberduck.Inspections/Concrete/EmptyForLoopBlockInspection.cs
@@ -16,7 +16,7 @@ namespace Rubberduck.Inspections.Concrete
         public EmptyForLoopBlockInspection(RubberduckParserState state)
             : base(state, CodeInspectionSeverity.DoNotShow) { }
 
-        public override CodeInspectionType InspectionType => CodeInspectionType.CodeQualityIssues;
+        public override CodeInspectionType InspectionType => CodeInspectionType.MaintainabilityAndReadabilityIssues;
 
         protected override IEnumerable<IInspectionResult> DoGetInspectionResults()
         {

--- a/Rubberduck.Inspections/Concrete/EmptyIfBlockInspection.cs
+++ b/Rubberduck.Inspections/Concrete/EmptyIfBlockInspection.cs
@@ -18,7 +18,7 @@ namespace Rubberduck.Inspections.Concrete
         public EmptyIfBlockInspection(RubberduckParserState state)
             : base(state, CodeInspectionSeverity.DoNotShow) { }
 
-        public override CodeInspectionType InspectionType => CodeInspectionType.CodeQualityIssues;
+        public override CodeInspectionType InspectionType => CodeInspectionType.MaintainabilityAndReadabilityIssues;
 
         protected override IEnumerable<IInspectionResult> DoGetInspectionResults()
         {

--- a/Rubberduck.Inspections/Concrete/EmptyWhileWendBlockInspection.cs
+++ b/Rubberduck.Inspections/Concrete/EmptyWhileWendBlockInspection.cs
@@ -16,7 +16,7 @@ namespace Rubberduck.Inspections.Concrete
         public EmptyWhileWendBlockInspection(RubberduckParserState state)
             : base(state, CodeInspectionSeverity.DoNotShow) { }
 
-        public override CodeInspectionType InspectionType => CodeInspectionType.CodeQualityIssues;
+        public override CodeInspectionType InspectionType => CodeInspectionType.MaintainabilityAndReadabilityIssues;
 
         protected override IEnumerable<IInspectionResult> DoGetInspectionResults()
         {


### PR DESCRIPTION
Update to MaintainabilityAndReadabilityIssues in empty block inspections

Fixes issue https://github.com/rubberduck-vba/Rubberduck/issues/3473